### PR TITLE
refactor: use CommonJS modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project provides a boilerplate Express server setup with TypeScript for bui
 
 ## Prerequisites 📋
 
-- [Node.js](https://nodejs.org/) - JavaScript runtime
+- [Node.js](https://nodejs.org/) (v20+ recommended) - JavaScript runtime
 - [Docker](https://www.docker.com/) - Containerization platform
 
 ## Installation and Deployment 🔧📦
@@ -19,6 +19,8 @@ _Under src/api, create a new folder that has to contain all the files representi
 2. <featureName>.controller.ts - controller where 'featureName' will be the class name. E.g. user.controller.ts -> class UserController
 
 _At the root of the project, create a .env file that must contains the environment variables as shown in the .env.example:_
+
+> **Note:** The TypeScript sources compile to CommonJS. When importing local files, omit the file extension (e.g. `import foo from './foo'`).
 
 1. **Local Development:**
    - Clone the repository and navigate to the project directory.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,10 +1,10 @@
-import js from '@eslint/js';
-import tsParser from '@typescript-eslint/parser';
-import tsPlugin from '@typescript-eslint/eslint-plugin';
-import prettierPlugin from 'eslint-plugin-prettier';
-import jestPlugin from 'eslint-plugin-jest';
+const js = require('@eslint/js');
+const tsParser = require('@typescript-eslint/parser');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const prettierPlugin = require('eslint-plugin-prettier');
+const jestPlugin = require('eslint-plugin-jest');
 
-export default [
+module.exports = [
   js.configs.recommended,
 
   {
@@ -21,8 +21,8 @@ export default [
         process: 'readonly',
         __dirname: 'readonly',
         __filename: 'readonly',
-        console: 'readonly'
-      }
+        console: 'readonly',
+      },
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
@@ -36,8 +36,8 @@ export default [
       'spaced-comment': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-empty-function': 'error',
-      '@typescript-eslint/no-unused-vars': 'warn'
-    }
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
   },
   {
     files: ['**/*.test.ts'],
@@ -51,14 +51,14 @@ export default [
         expect: 'readonly',
         beforeEach: 'readonly',
         afterEach: 'readonly',
-      }
+      },
     },
     rules: {
       'jest/no-disabled-tests': 'warn',
       'jest/no-focused-tests': 'error',
       'jest/no-identical-title': 'error',
       'jest/prefer-to-have-length': 'warn',
-      'jest/valid-expect': 'error'
-    }
-  }
+      'jest/valid-expect': 'error',
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "basic-express-server",
   "version": "1.1.0",
   "description": "express and typescript server bootstrap",
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import ConfigService from '../config/config.js';
+import ConfigService from '../config/config';
 import {Router} from 'express';
 import fs from 'fs';
 import path from 'path';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import app from './server.js';
+import app from './server';
 
 // init server
 app.startServer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import routes from './api';
+import routes from './api/index';
 import * as expressWinston from 'express-winston';
 import {Logger} from './services/Logger/Logger.service';
 import {errorHandler} from './middlewares/ErrorHandler.middleware';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ESNext",                                /* Specify what module code is generated. */
+    "module": "commonjs",                               /* Specify what module code is generated. */
     "rootDir": "src",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": "src",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION

- configure project for CommonJS by updating package and TypeScript settings
- drop `.js` extensions and ESM-specific path handling across server utilities
- convert ESLint config to CommonJS and document new import style
